### PR TITLE
Ltrace requires dynamic linking and lazy binding

### DIFF
--- a/content/chapters/software-stack/lab/support/libc/Makefile
+++ b/content/chapters/software-stack/lab/support/libc/Makefile
@@ -1,5 +1,5 @@
 CFLAGS = -Wall
-LDFLAGS = -static
+LDFLAGS = -z lazy
 
 .PHONY: all clean
 


### PR DESCRIPTION
In order to run `ltrace` the executable should be dynamically linked and lazy binding.