### PR TITLE
lab/software-stack: Add missing -fno-builtin flag in Makefile

### DIFF
--- a/content/chapters/software-stack/lab/support/common-functions/Makefile
+++ b/content/chapters/software-stack/lab/support/common-functions/Makefile
@@ -1,6 +1,6 @@
 NASM = nasm
 CC = gcc
-CFLAGS = -fno-PIC -fno-stack-protector
+CFLAGS = -fno-PIC -fno-stack-protector -fno-builtin
 LDFLAGS = -nostdlib -no-pie -Wl,--entry=main -Wl,--build-id=none
 
 .PHONY: all clean


### PR DESCRIPTION
Missing `-fno-builtin` flag from `Makefile` caused the compiler to substitute `str*` calls from `content/chapters/software-stack/lab/support/common-functions/main_string` with builin functions, instead of use custom implementations from `content/chapters/software-stack/lab/support/common-functions/string.c`.

