### PR TITLE
actions/pr-deployment: Fix deployment URL

### DIFF
--- a/.github/workflows/pr-deployment.yml
+++ b/.github/workflows/pr-deployment.yml
@@ -64,4 +64,4 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
-            Published at http://open-education-hub.github.io/operating-systems/${{ github.event.number }}/
+            Published at https://${{ github.repository_owner }}.github.io/operating-systems/${{ github.event.number }}/


### PR DESCRIPTION
The URL was `http://open-education-hub.github.io/...`. This was incorrect for forked repos as it referred to the original owner: OEH. In addition, it was using the `http` scheme instead of `https`. This was less of an issue because the `http` endpoint redirects to `https`.

This commit fixes both of the aforementioned problems by dynamically obtaining the owner uwing `${{ github.repository_owner }}` and by using `https` instead of `http`.