### PR TITLE
asg/mem-alloc: Remove block expansion from split-one-block test

### DIFF
--- a/content/assignments/memory-allocator/.vscode/launch.json
+++ b/content/assignments/memory-allocator/.vscode/launch.json
@@ -1,0 +1,69 @@
+{
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Run test",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceFolder}/tests/snippets/${input:testName}",
+            "cwd": "${fileDirname}",
+            "environment": [
+                {
+                    "name": "LD_LIBRARY_PATH",
+                    "value": "${workspaceFolder}/src"
+                },
+            ],
+            "MIMode": "gdb"
+        }
+    ],
+    "inputs": [
+        {
+            "id": "testName",
+            "description": "Select test to run",
+            "type": "pickString",
+            "options": [
+                "test-all",
+                "test-calloc-arrays",
+                "test-calloc-block-reuse",
+                "test-calloc-coalesce",
+                "test-calloc-coalesce-big",
+                "test-calloc-expand-block",
+                "test-calloc-no-preallocate",
+                "test-calloc-no-split",
+                "test-calloc-preallocate",
+                "test-calloc-split-first",
+                "test-calloc-split-last",
+                "test-calloc-split-middle",
+                "test-calloc-split-one-block",
+                "test-calloc-split-vector",
+                "test-malloc-arrays",
+                "test-malloc-block-reuse",
+                "test-malloc-coalesce",
+                "test-malloc-coalesce-big",
+                "test-malloc-expand-block",
+                "test-malloc-no-preallocate",
+                "test-malloc-no-split",
+                "test-malloc-preallocate",
+                "test-malloc-split-first",
+                "test-malloc-split-last",
+                "test-malloc-split-middle",
+                "test-malloc-split-one-block",
+                "test-malloc-split-vector",
+                "test-realloc-arrays",
+                "test-realloc-block-reuse",
+                "test-realloc-coalesce",
+                "test-realloc-coalesce-big",
+                "test-realloc-expand-block",
+                "test-realloc-no-preallocate",
+                "test-realloc-no-split",
+                "test-realloc-preallocate",
+                "test-realloc-split-first",
+                "test-realloc-split-last",
+                "test-realloc-split-middle",
+                "test-realloc-split-one-block",
+                "test-realloc-split-vector"
+            ],
+        }
+    ]
+}

--- a/content/assignments/memory-allocator/README.md
+++ b/content/assignments/memory-allocator/README.md
@@ -309,9 +309,9 @@ Every other address is displayed as `<label> + offset`, where the label is the c
 If you want to run a single test, you give its name or its path as arguments to `run_tests.py`:
 
 ```console
-student@os:~/.../mem-alloc/tests$ python run_tests.py test-all
+student@os:~/.../mem-alloc/tests$ python3 run_tests.py test-all
 OR
-student@os:~/.../mem-alloc/tests$ python run_tests.py snippets/test-all
+student@os:~/.../mem-alloc/tests$ python3 run_tests.py snippets/test-all
 ```
 
 ### Debugging in VSCode

--- a/content/assignments/memory-allocator/tests/Makefile
+++ b/content/assignments/memory-allocator/tests/Makefile
@@ -27,11 +27,11 @@ clean_src:
 
 check:
 	$(MAKE) clean_src clean_snippets src snippets
-	python run_tests.py
+	python3 run_tests.py
 
 check-fast:
 	$(MAKE) clean_src clean_snippets src snippets
-	python run_tests.py -d
+	python3 run_tests.py -d
 
 lint:
 	-cd .. && checkpatch.pl -f src/*.c tests/snippets/*.c

--- a/content/assignments/memory-allocator/tests/ref/test-malloc-split-one-block.ref
+++ b/content/assignments/memory-allocator/tests/ref/test-malloc-split-one-block.ref
@@ -10,8 +10,6 @@ os_malloc (['4096'])                                                            
 os_malloc (['2048'])                                                                      = HeapStart + 0x1f0c0
 os_malloc (['1024'])                                                                      = HeapStart + 0x1f8e0
 os_malloc (['512'])                                                                       = HeapStart + 0x1fd00
-os_malloc (['256'])                                                                       = HeapStart + 0x1ff20
-  brk (['HeapStart + 0x20020'])                                                           = HeapStart + 0x20020
 os_free (['HeapStart + 0x20'])                                                            = <void>
 os_free (['HeapStart + 0x10040'])                                                         = <void>
 os_free (['HeapStart + 0x18060'])                                                         = <void>
@@ -20,5 +18,4 @@ os_free (['HeapStart + 0x1e0a0'])                                               
 os_free (['HeapStart + 0x1f0c0'])                                                         = <void>
 os_free (['HeapStart + 0x1f8e0'])                                                         = <void>
 os_free (['HeapStart + 0x1fd00'])                                                         = <void>
-os_free (['HeapStart + 0x1ff20'])                                                         = <void>
 +++ exited (status 0) +++

--- a/content/assignments/memory-allocator/tests/ref/test-realloc-split-one-block.ref
+++ b/content/assignments/memory-allocator/tests/ref/test-realloc-split-one-block.ref
@@ -10,8 +10,6 @@ os_realloc (['0', '4096'])                                                      
 os_realloc (['0', '2048'])                                                                = HeapStart + 0x1f0c0
 os_realloc (['0', '1024'])                                                                = HeapStart + 0x1f8e0
 os_realloc (['0', '512'])                                                                 = HeapStart + 0x1fd00
-os_realloc (['0', '256'])                                                                 = HeapStart + 0x1ff20
-  brk (['HeapStart + 0x20020'])                                                           = HeapStart + 0x20020
 os_realloc (['HeapStart + 0x20', '0'])                                                    = 0
 os_realloc (['HeapStart + 0x18060', '32798'])                                             = HeapStart + 0x20
 os_realloc (['HeapStart + 0x1c080', '16414'])                                             = HeapStart + 0x8060
@@ -27,5 +25,4 @@ os_free (['HeapStart + 0xc0a0'])                                                
 os_free (['HeapStart + 0xe0e0'])                                                          = <void>
 os_free (['HeapStart + 0xf120'])                                                          = <void>
 os_free (['HeapStart + 0xf960'])                                                          = <void>
-os_free (['HeapStart + 0x1ff20'])                                                         = <void>
 +++ exited (status 0) +++

--- a/content/assignments/memory-allocator/tests/snippets/test-malloc-split-one-block.c
+++ b/content/assignments/memory-allocator/tests/snippets/test-malloc-split-one-block.c
@@ -2,13 +2,15 @@
 
 #include "test-utils.h"
 
+#define NUM_SIZES 8
+
 int main(void)
 {
-	int sizes[9];
-	void *prealloc_ptr, *ptrs[9];
+	int sizes[NUM_SIZES];
+	void *prealloc_ptr, *ptrs[NUM_SIZES];
 
 	/* Init sizes */
-	for (int i = 0; i < 9; i++)
+	for (int i = 0; i < NUM_SIZES; i++)
 		sizes[i] = MMAP_THRESHOLD / (1 << (i + 1));
 
 	/* Create a free block */
@@ -16,11 +18,11 @@ int main(void)
 	os_free(prealloc_ptr);
 
 	/* Split the chunk multiple times */
-	for (int i = 0; i < 9; i++)
+	for (int i = 0; i < NUM_SIZES; i++)
 		ptrs[i] = os_malloc_checked(sizes[i]);
 
 	/* Cleanup */
-	for (int i = 0; i < 9; i++)
+	for (int i = 0; i < NUM_SIZES; i++)
 		os_free(ptrs[i]);
 
 	return 0;

--- a/content/assignments/memory-allocator/tests/snippets/test-realloc-split-one-block.c
+++ b/content/assignments/memory-allocator/tests/snippets/test-realloc-split-one-block.c
@@ -2,13 +2,15 @@
 
 #include "test-utils.h"
 
+#define NUM_SIZES 8
+
 int main(void)
 {
-	int sizes[9];
-	void *prealloc_ptr, *ptrs[9];
+	int sizes[NUM_SIZES];
+	void *prealloc_ptr, *ptrs[NUM_SIZES];
 
 	/* Init sizes */
-	for (int i = 0; i < 9; i++)
+	for (int i = 0; i < NUM_SIZES; i++)
 		sizes[i] = MMAP_THRESHOLD / (1 << (i + 1));
 
 	/* Create a free block */
@@ -17,7 +19,7 @@ int main(void)
 	os_free(prealloc_ptr);
 
 	/* Split the chunk multiple times */
-	for (int i = 0; i < 9; i++)
+	for (int i = 0; i < NUM_SIZES; i++)
 		ptrs[i] = os_realloc_checked(NULL, sizes[i]);
 
 	/* Free the first ptr and reallocate the others */
@@ -28,7 +30,7 @@ int main(void)
 		ptrs[i] = os_realloc_checked(ptrs[i], sizes[i-1] + 30);
 
 	/* Cleanup */
-	for (int i = 0; i < 9; i++)
+	for (int i = 0; i < NUM_SIZES; i++)
 		os_free(ptrs[i]);
 
 	return 0;


### PR DESCRIPTION
* Sync with GitLab:
  * Add vscode script for running and debugging the assignment's tests.
  * Use python3 instead of Python in Makefile and README.md.
* Remove block expansion from `split-one-block` test

- [x] Fix `test-realloc-split-one-block` too