### PR TITLE
compute/fix sum-array-bugs/seg-fault Makefile

### DIFF
--- a/content/chapters/compute/lab/support/sum-array-bugs/seg-fault/Makefile
+++ b/content/chapters/compute/lab/support/sum-array-bugs/seg-fault/Makefile
@@ -1,5 +1,6 @@
 BINARIES = sum_array_threads sum_array_processes
 include ../../../../../../common/makefile/multiple.mk
+LDLIBS += -lpthread
 
 sum_array_threads: sum_array_threads.o generate_random_array.o
 


### PR DESCRIPTION
Add `-pthread` to LDFLAGS when compiling using `<pthread.h>`.