### PR TITLE
compute/lab: Fix incorrect function name

### DIFF
--- a/content/chapters/compute/lab/content/synchronization.md
+++ b/content/chapters/compute/lab/content/synchronization.md
@@ -52,7 +52,7 @@ When a thread calls `pthread_mutex_lock()`, it attempts to set that variable to 
 If it was 0, the thread sets it to 1 and proceeds to execute the critical section.
 Otherwise, it **suspends its execution** and waits until that variable is set to 0 again.
 
-When calling `pthread_mute_unlock()`, the internal variable is set to 0 and all waiting threads are woken up to try to acquire the mutex again.
+When calling `pthread_mutex_unlock()`, the internal variable is set to 0 and all waiting threads are woken up to try to acquire the mutex again.
 **Be careful:** It is generally considered unsafe and [in many cases undefined behaviour](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_mutex_lock.html) to call `pthread_mutex_unlock()` from a different thread than the one that acquired the lock.
 So the general workflow should look something like this:
 


### PR DESCRIPTION

# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [ ] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Fix incorrect function name: replaced pthread_mute_unlock() with pthread_mutex_unlock().

