### PR TITLE
Update command to show expected output

### DIFF
--- a/content/chapters/compute/lab/content/arena.md
+++ b/content/chapters/compute/lab/content/arena.md
@@ -8,17 +8,17 @@ For this, we'll run both `sum_array_threads` and `sum_array_processes` under `st
 As we've already established, we're only interested in the `clone` syscall:
 
 ```console
-student@os:~/.../lab/support/sum-array/c$ strace -e clone ./sum_array_threads 2
+student@os:~/.../lab/support/sum-array/c$ strace -e clone,clone3 ./sum_array_threads 2
 clone(child_stack=0x7f60b56482b0, flags=CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, parent_tid=[1819693], tls=0x7f60b5649640, child_tidptr=0x7f60b5649910) = 1819693
 clone(child_stack=0x7f60b4e472b0, flags=CLONE_VM|CLONE_FS|CLONE_FILES|CLONE_SIGHAND|CLONE_THREAD|CLONE_SYSVSEM|CLONE_SETTLS|CLONE_PARENT_SETTID|CLONE_CHILD_CLEARTID, parent_tid=[1819694], tls=0x7f60b4e48640, child_tidptr=0x7f60b4e48910) = 1819694
 
-student@os:~/.../lab/support/sum-array/c$ strace -e clone ./sum_array_processes 2
+student@os:~/.../lab/support/sum-array/c$ strace -e clone,clone3 ./sum_array_processes 2
 clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD, child_tidptr=0x7f7a4e346650) = 1820599
 clone(child_stack=NULL, flags=CLONE_CHILD_CLEARTID|CLONE_CHILD_SETTID|SIGCHLD, child_tidptr=0x7f7a4e346650) = 1820600
 ```
 
 We ran each program with an argument of 2, so we have 2 calls to `clone`.
-Notice that in the case of threads, the `clone` syscall receives more arguments.
+Notice that in the case of threads, the `clone3 syscall receives more arguments.
 The relevant flags passed as arguments when creating threads are documented in [`clone`'s man page](https://man.archlinux.org/man/clone3.2.en):
 
 - `CLONE_VM`: the child and the parent process share the same VAS

--- a/content/chapters/compute/lab/content/synchronization.md
+++ b/content/chapters/compute/lab/content/synchronization.md
@@ -95,7 +95,7 @@ But now we need a critical section to implement a critical section...
 To solve this circular problem, we make use of a very common _Deus ex Machina_: **hardware support**.
 
 Modern processors are capable of _atomically_ accessing data, either for reads or writes.
-An atomic action is and indivisible sequence of operations that a thread runs without interference from others.
+An atomic action is an indivisible sequence of operations that a thread runs without interference from others.
 Concretely, before initiating an atomic transfer on one of its data buses, the CPU first makes sure all other transfers have ended, then **locks** the data bus by stalling all cores attempting to transfer data on it.
 This way, one thread obtains **exclusive** access to the data bus while accessing data.
 As a side note, the critical sections in `support/race-condition/c/race_condition_mutex.c` are also atomic once they are wrapped between calls to `pthread_mutex_lock()` and `pthread_mutex_unlock()`.


### PR DESCRIPTION
# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Calling `strace -e clone ./sum_array_threads 2` would not show the clone3 syscall.
Replacing `clone` with `clone,clone3` in both commands allows the syscalls to display as expected.

A small typo has also been fixed.