### PR TITLE
io/lab: Fix strtok_r usage in Mini-shell

### DIFF
--- a/content/chapters/io/lab/solution/mini-shell/mini_shell.c
+++ b/content/chapters/io/lab/solution/mini-shell/mini_shell.c
@@ -52,7 +52,8 @@ static void simple_cmd(char **args)
 	pid_t wait_ret;
 	int status;
 
-	/** Create a process to execute the command. Use `execvp` to launch the
+	/**
+	 * Create a process to execute the command. Use `execvp` to launch the
 	 * new process.
 	 */
 	pid = fork();
@@ -66,9 +67,8 @@ static void simple_cmd(char **args)
 		/* Child process */
 
 		/**
-		 * TODO: Call `do_redirect()`. Assume the only file descriptor
-		 * that needs to be redirected is `stdout`. Its file descriptor
-		 * is `STDOUT_FILENO`.
+		 * Call `do_redirect()`. Assume the only file descriptor that needs to
+		 * be redirected is `stdout`. Its file descriptor is `STDOUT_FILENO`.
 		 */
 		if (stdout_file != NULL)
 			do_redirect(STDOUT_FILENO, stdout_file);
@@ -138,8 +138,9 @@ static int parse_line(char *line)
 {
 	int ret = SIMPLE;
 	int idx = 0;
-	char *token; 
+	char *token;
 	char *delim = "=\n";
+	char *saveptr = NULL;
 
 	stdin_file = NULL;
 	stdout_file = NULL;
@@ -151,7 +152,7 @@ static int parse_line(char *line)
 
 	/* Regular command. */
 	delim = " \t\n";
-	token = strtok(line, delim);
+	token = strtok_r(line, delim, &saveptr);
 
 	if (token == NULL)
 		return ERROR;
@@ -170,14 +171,14 @@ static int parse_line(char *line)
 				token++;
 				stdout_file = strdup(token);
 			} else {
-				token = strtok(NULL, delim);
+				token = strtok_r(NULL, delim, &saveptr);
 				stdout_file = strdup(token);
 			}
 		} else {
 			args[idx++] = strdup(token);
 		}
 
-		token = strtok(NULL, delim);
+		token = strtok_r(NULL, delim, &saveptr);
 	}
 
 	args[idx++] = NULL;

--- a/content/chapters/io/lab/support/mini-shell/mini_shell.c
+++ b/content/chapters/io/lab/support/mini-shell/mini_shell.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-3-Clause */
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -58,9 +58,8 @@ static void simple_cmd(char **args)
 		/* Child process */
 
 		/**
-		 * TODO: Call `do_redirect()`. Assume the only file descriptor
-		 * that needs to be redirected is `stdout`. Its file descriptor
-		 * is `STDOUT_FILENO`.
+		 * Call `do_redirect()`. Assume the only file descriptor that needs to
+		 * be redirected is `stdout`. Its file descriptor is `STDOUT_FILENO`.
 		 */
 		if (stdout_file != NULL)
 			do_redirect(STDOUT_FILENO, stdout_file);
@@ -132,6 +131,7 @@ static int parse_line(char *line)
 	int idx = 0;
 	char *token;
 	char *delim = "=\n";
+	char *saveptr = NULL;
 
 	stdin_file = NULL;
 	stdout_file = NULL;
@@ -143,7 +143,7 @@ static int parse_line(char *line)
 
 	/* Regular command. */
 	delim = " \t\n";
-	token = strtok_r(line, delim);
+	token = strtok_r(line, delim, &saveptr);
 
 	if (token == NULL)
 		return ERROR;
@@ -162,14 +162,14 @@ static int parse_line(char *line)
 				token++;
 				stdout_file = strdup(token);
 			} else {
-				token = strtok_r(NULL, delim);
+				token = strtok_r(NULL, delim, &saveptr);
 				stdout_file = strdup(token);
 			}
 		} else {
 			args[idx++] = strdup(token);
 		}
 
-		token = strtok_r(NULL, delim);
+		token = strtok_r(NULL, delim, &saveptr);
 	}
 
 	args[idx++] = NULL;


### PR DESCRIPTION
# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

Currently the code fails to compile because `strtok_r` is not provided the `saveptr` argument.

This pull request fixes this and synchronizes the changes to the solution. It also removes the `TODO:` marker from one of the comments as there is nothing to do.