### PR TITLE
app-interact/lecture: Change reference to reader/sender demo

### DIFF
--- a/content/chapters/app-interact/lecture/slides/defs.md
+++ b/content/chapters/app-interact/lecture/slides/defs.md
@@ -36,9 +36,9 @@ int main(void)
 
 ### Exhibit 1 - Creating Interaction
 
-- `demo/send-receive/reader.c`
-- `demo/send-receive/writer.c`
-- `demo/send-receive/send_receive_pipe.c`
+- `demo/comm-channels/reader.c`
+- `demo/comm-channels/writer.c`
+- `demo/comm-channels/send_receive_pipe.c`
 
 ---
 


### PR DESCRIPTION
# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [n/a] Tested your changes against relevant architectures and platforms;
- [n/a] Updated relevant documentation (if needed).

## Description of changes

The slides were incorrectly referencing demos in the `demo/send-receive/` folder, which doesn't exits. This replaces `send-receive` with the correct folder name: `comm-channels`.
