### PR TITLE
io/lab/quiz: Mention `copy_file_range` syscall for `cp`

### DIFF
--- a/content/chapters/io/lab/quiz/mmap-read-write-benchmark.md
+++ b/content/chapters/io/lab/quiz/mmap-read-write-benchmark.md
@@ -12,6 +12,8 @@ According to the times shown by `benchmark_cp.sh`, which of the two implementati
 
 + they are roughly equivalent
 
++ `cp` is faster if it uses `copy_file_range()`
+
 ## Feedback
 
 In our case, running the script a few times results in the following running times:
@@ -23,12 +25,12 @@ Benchmarking mmap_cp on a 1GB file...
 
 real    0m30,597s
 user    0m0,569s
-sys	0m2,286s
+sys     0m2,286s
 Benchmarking cp on a 1 GB file...
 
 real    0m36,012s
 user    0m0,039s
-sys	0m2,469s
+sys     0m2,469s
 
 
 student@os:/.../support/file-mappings$ ./benchmark_cp.sh
@@ -37,12 +39,12 @@ Benchmarking mmap_cp on a 1 GB file...
 
 real    0m27,803s
 user    0m0,590s
-sys	0m2,114s
+sys     0m2,114s
 Benchmarking cp on a 1 GB file...
 
 real    0m35,607s
 user    0m0,033s
-sys	0m2,564s
+sys     0m2,564s
 ```
 
 So it seems that using `mmap()` rather than `read()` and `write()` yields about a 15% increase in performance.
@@ -51,3 +53,21 @@ This depends on your storage device (SSD vs HDD) and its specific speed (like it
 So the more conservative answer is to say that this depends on external aspects and that, in general, the 2 implementations are more or less equivalent.
 
 If you want to know why there isn't much of a difference between the 2 implementations, check out [this explanation](https://stackoverflow.com/a/27987994).
+
+However, some newer Linux systems use an updated `cp` that doesn't use `read` and `write` anymore, but instead uses zero-copy, by means of the `copy_file_range()` syscall.
+This implementation is likely going to be significantly faster than the one using `mmap`, as shown in the snippet below:
+
+```console
+student@os:/.../support/file-mappings$ ./benchmark_cp.sh
+make: Nothing to be done for 'all'.
+Benchmarking mmap_cp on a 1 GB file...
+
+real    0m1,443s
+user    0m0,429s
+sys     0m0,971s
+Benchmarking cp on a 1 GB file...
+
+real    0m0,821s
+user    0m0,001s
+sys     0m0,602s
+```


### PR DESCRIPTION
# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

`coreutils` 9.0 reimplemented `cp` using the `copy_file_range()` syscall, which performs zero-copy [1]. Therefore, the existing comparison between `mmap_cp` and `cp` is no longer valid. This commit mentions the new implementation and its effects on performance. This version of `coreutils` is available by default on newer Ubuntu systems such as 23.04.

[1] https://lists.gnu.org/archive/html/info-gnu/2021-09/msg00010.html
