### PR TITLE
chapters/software-stack: Fix links to immages in the slids

### DIFF
--- a/chapters/software-stack/modern-software-stacks/slides/modern-software-stacks.md
+++ b/chapters/software-stack/modern-software-stacks/slides/modern-software-stacks.md
@@ -6,47 +6,47 @@
 
 ### Android Software Stack
 
-<img src="../media/android-software-stack.png" alt="Android Software Stack" width="40%" />
+<img src="modern-software-stacks/media/android-software-stack.png" alt="Android Software Stack" width="40%" />
 <!-- https://www.pcloudy.com/android-and-ios-basics-and-comparison/ -->
 
 ----
 
 ### iOS Software Stack
 
-<img src="../media/ios-software-stack.png" alt="iOS Software Stack" width="50%" />
+<img src="modern-software-stacks/media/ios-software-stack.png" alt="iOS Software Stack" width="50%" />
 <!-- https://www.pcloudy.com/android-and-ios-basics-and-comparison/ -->
 
 ----
 
 ### Windows Software Stack
 
-![Windows](../media/windows.png)
+![Windows](modern-software-stacks/media/windows.png)
 <!-- https://medium.com/@putrasulung2108/windows-architecture-d2b022f136d3 -->
 
 ----
 
 ### macOS Software Stack
 
-![macOS](../media/macos.svg)
+![macOS](modern-software-stacks/media/macos.svg)
 <!-- https://en.wikipedia.org/wiki/Architecture_of_macOS -->
 
 ----
 
 ### Linux Software Stack
 
-![Linux](../media/linux.svg)
+![Linux](modern-software-stacks/media/linux.svg)
 <!-- https://en.wikipedia.org/wiki/Linux -->
 
 ----
 
 ### RIOT (IoT devices)
 
-![Tock](../media/riot.png)
+![Tock](modern-software-stacks/media/riot.png)
 <!-- https://desosa.nl/projects/riot/2020/03/19/riot-from-vision-to-architecture.html -->
 
 ----
 
 ### Tock (low-power microcontrollers)
 
-<img src="../media/tock.png" alt="Tock" width="60%" />
+<img src="modern-software-stacks/media/tock.png" alt="Tock" width="60%" />
 <!-- https://www.tockos.org/documentation/design/ -->

--- a/chapters/software-stack/operating-system-types/slides/os-types.md
+++ b/chapters/software-stack/operating-system-types/slides/os-types.md
@@ -60,7 +60,7 @@
 
 ### Unikraft
 
-![Unikraft](../media/unikraft.png)
+![Unikraft](operating-system-types/media/unikraft.png)
 <!-- https://www.usenix.org/publications/loginonline/unikraft-and-coming-age-unikernels -->
 
 ----
@@ -75,7 +75,7 @@
 
 ### The L4 Microkernel
 
-![L4](../media/l4.png)
+![L4](operating-system-types/media/l4.png)
 <!-- https://www.researchgate.net/figure/Nizza-Security-Architecture-The-picture-illustrates-the-overall-architecture-of-Nizza_fig1_233765184 -->
 
 ----
@@ -92,7 +92,7 @@
 
 ### The Linux Kernel
 
-![Linux](../media/linux-kernel.png)
+![Linux](operating-system-types/media/linux-kernel.png)
 <!-- https://linux-kernel-labs.github.io/refs/heads/master/lectures/arch.html -->
 
 ----
@@ -107,5 +107,5 @@
 
 ### Xen and KVM
 
-![Xen](../media/xen-kvm.jpeg)
+![Xen](operating-system-types/media/xen-kvm.jpeg)
 <!-- https://medium.com/@saisarathchandrap/virtualisation-at-alibaba-cloud-b20dea72efa1 -->

--- a/chapters/software-stack/operating-system/slides/operating-system.md
+++ b/chapters/software-stack/operating-system/slides/operating-system.md
@@ -28,14 +28,14 @@
 
 ### OS: Library-like Component
 
-![OS Components](../media/os-components.jpg)
+![OS Components](operating-system/media/os-components.jpg)
 <!-- https://technologyrediscovery.net/compFund/obcat.comp.os.html -->
 
 ----
 
 ### System Call Interface
 
-![OS Layers](../media/os-layers.png)
+![OS Layers](operating-system/media/os-layers.png)
 <!-- https://cse.buffalo.edu/~bina/cse321/fall2017/Lectures/Sept6System.html -->
 
 ----
@@ -74,13 +74,13 @@
 
 Security role: _Reference Monitor_
 
-![OS as Reference Monitor](../media/os-reference-monitor.svg)
+![OS as Reference Monitor](operating-system/media/os-reference-monitor.svg)
 
 ----
 
 ### User Mode, Kernel Mode
 
-![User Mode / Kernel Mode](../media/user-kernel-mode.png)
+![User Mode / Kernel Mode](operating-system/media/user-kernel-mode.png)
 
 ----
 
@@ -144,13 +144,13 @@ Security role: _Reference Monitor_
 
 Also called **supervisor mode**
 
-![Dual Mode](../media/dual-mode.jpeg)
+![Dual Mode](operating-system/media/dual-mode.jpeg)
 
 ----
 
 ### Standard C Library
 
-![libc](../media/libc.svg)
+![libc](operating-system/media/libc.svg)
 
 ----
 

--- a/chapters/software-stack/overview/slides/software-stack.md
+++ b/chapters/software-stack/overview/slides/software-stack.md
@@ -4,19 +4,19 @@
 
 ---
 
-![What We Have](../media/hardware-software/1-hardware.svg)
+![What We Have](overview/media/hardware-software/1-hardware.svg)
 
 ----
 
-![What We Want](../media/hardware-software/2-features.svg)
+![What We Want](overview/media/hardware-software/2-features.svg)
 
 ----
 
-![Have to Want](../media/hardware-software/3-software.svg)
+![Have to Want](overview/media/hardware-software/3-software.svg)
 
 ----
 
-![Hardware + Software](../media/software-use.svg)
+![Hardware + Software](overview/media/software-use.svg)
 
 ----
 
@@ -54,19 +54,19 @@
 
 ### Reusability
 
-<img src="../media/software-reuse.png" alt="Reusability" width="60%" />
+<img src="overview/media/software-reuse.png" alt="Reusability" width="60%" />
 <!-- https://medium.com/application-library-engineering-group/a-deep-dive-into-reusable-components-3788ca756390 -->
 
 ----
 
-![Don't Reinvent the Wheel](../media/dont-reinvent-the-wheel.jpeg)
+![Don't Reinvent the Wheel](overview/media/dont-reinvent-the-wheel.jpeg)
 <!-- https://levelup.gitconnected.com/software-engineering-best-practices-for-reusing-in-software-development-6006f9d8d364 -->
 
 ----
 
 ### Portability
 
-![Portability](../media/portability.svg)
+![Portability](overview/media/portability.svg)
 
 ----
 
@@ -74,13 +74,13 @@
 
 Same software, different use cases
 
-![Software Configurability](../media/software-configurability.svg)
+![Software Configurability](overview/media/software-configurability.svg)
 
 ---
 
 ### Interface and Implementation
 
-![Interface and Implementation](../media/interface-implementation.svg)
+![Interface and Implementation](overview/media/interface-implementation.svg)
 
 ----
 
@@ -95,13 +95,13 @@ Same software, different use cases
 
 ### Portability vs Performance
 
-![Portability vs Performance](../media/portability-performance.svg)
+![Portability vs Performance](overview/media/portability-performance.svg)
 
 ---
 
 ### Software Stack
 
-![Software Stack](../media/software-stack.svg)
+![Software Stack](overview/media/software-stack.svg)
 
 ----
 
@@ -115,19 +115,19 @@ Same software, different use cases
 
 ### Android Software Stack
 
-<img src="../media/android-software-stack.png" alt="Android Software Stack" width="40%" />
+<img src="overview/media/android-software-stack.png" alt="Android Software Stack" width="40%" />
 <!-- https://www.pcloudy.com/android-and-ios-basics-and-comparison/ -->
 
 ----
 
 ### iOS Software Stack
 
-<img src="../media/ios-software-stack.png" alt="iOS Software Stack" width="50%" />
+<img src="overview/media/ios-software-stack.png" alt="iOS Software Stack" width="50%" />
 <!-- https://www.pcloudy.com/android-and-ios-basics-and-comparison/ -->
 
 ----
 
 ### Flutter Framework
 
-![iOS Software Stack](../media/flutter.png)
+![iOS Software Stack](overview/media/flutter.png)
 <!-- https://buildflutter.com/how-flutter-works/ -->

--- a/chapters/software-stack/software-types/slides/types-of-software.md
+++ b/chapters/software-stack/software-types/slides/types-of-software.md
@@ -19,26 +19,26 @@
 
 ### Applications
 
-![Applications](../media/applications.svg)
+![Applications](software-types/media/applications.svg)
 
 ----
 
 ### Libraries
 
-![Libraries](../media/libraries.svg)
+![Libraries](software-types/media/libraries.svg)
 
 ----
 
 ### Application Software and System Software
 
-![Application and System Software](../media/application-system-software.png)
+![Application and System Software](software-types/media/application-system-software.png)
 <!-- https://www.webopedia.com/definitions/systems-software/ -->
 
 ----
 
 ### Libraries and Frameworks
 
-![Libraries and Frameworks](../media/libraries-frameworks.png)
+![Libraries and Frameworks](software-types/media/libraries-frameworks.png)
 <!-- https://medium.com/@MarcStevenCoder/build-reusable-frameworks-809438ef46e7 -->
 
 ----


### PR DESCRIPTION
# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

The links were made to `../media/<image-name>` in each subchapter's `slides/` folder. This made them work properly in the Markdown files in which they were imported, but not when those files were aggregated into the chapter-wide `slides.md` via MarkdownPP. The new links use paths starting from `slides.md`'s location and no longer work in their corresponding sub-files.
