### PR TITLE
misc/lab-setup: Remove Docker references

### DIFF
--- a/content/misc/lab-setup.md
+++ b/content/misc/lab-setup.md
@@ -35,14 +35,4 @@ student@os:~/operating-systems$ cd content/chapters/<chapter-name>/lab/
 
 The possible options are: `software-stack`, `data`, `compute`, `io` and `app-interact`.
 
-If you're using the OS-runner Docker container, you can use the following shortcuts:
-
-`go-ss`       - changes directory to Software Stack lab
-
-`go-data`     - changes directory to Data lab
-
-`go-compute`  - changes directory to Compute lab
-
-`go-io`       - changes directory to IO lab
-
-`go-appInt`   - changes directory to App Interaction lab
+You can work on any Linux setup (native install, `WSL`, `VM`), but we strongly recommend you use the [`operating-systems` class VMs](https://cs-pub-ro.github.io/operating-systems/resources#virtual-machine).


### PR DESCRIPTION
Since we will only be using VMs / native setups from now on, remove the Docker container references from the setup instructions.

