### PR TITLE
config: Replace "Syscall Tool" quiz with "Libc"

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -140,7 +140,7 @@ docusaurus:
                                 - strcpy System Call: strcpy-syscall.md
                                 - printf vs write: printf-vs-write.md
                                 - malloc: malloc.md
-                                - Syscall Tool: syscall-tool.md
+                                - Libc: libc.md
               - High-Level Languages:
                   path: chapters/software-stack/high-level-languages
                   extra:


### PR DESCRIPTION
# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

The name of the quiz file was incorrect in the config file.
