### PR TITLE
chapters/software-stack: Simplify `os_strcat()` implementation.

### DIFF
--- a/chapters/software-stack/libc/drills/tasks/common-functions/solution/src/.gitignore
+++ b/chapters/software-stack/libc/drills/tasks/common-functions/solution/src/.gitignore
@@ -1,0 +1,2 @@
+/main_string
+/main_printf

--- a/chapters/software-stack/libc/drills/tasks/common-functions/solution/src/os_string.c
+++ b/chapters/software-stack/libc/drills/tasks/common-functions/solution/src/os_string.c
@@ -23,7 +23,7 @@ char *os_strcpy(char *dest, const char *src)
 	return dest;
 }
 
-/* TODO 12: Implement strcat(). */
+/* TODO 25: Implement os_strcat(). */
 char *os_strcat(char *dest, const char *src)
 {
     char *rdest = dest;
@@ -31,8 +31,22 @@ char *os_strcat(char *dest, const char *src)
     while (*dest)
       dest++;
 
+	while (*src) {
+		*dest = *src;
+		dest++;
+		src++;
+	}
+
+	/*
+	 * A more difficult to understand, but shorter and smarter implementation is below.
+	 * The ++ operator is evaluated last, after checking the condition of the loop, so this condition can be
+	 * seen as simply *dest = *src followed by dest++ and src++ in the loop body, which is equivalent to the loop
+	 * above.
+	 */
+	/*
     while (*dest++ = *src++)
       ;
+	*/
 
     return rdest;
 }


### PR DESCRIPTION
# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

The solution provided to `os_strcat()` was too esotheric and not suited to be used by students wanting go learn how to implement `strcat()`. The current solution is a bit more verbose, but still includes the previous approac as a nice-to-know gimmick.
