### PR TITLE
chapters/software-stack: Fix paths

### DIFF
--- a/chapters/data/memory-security/drills/tasks/exec-shellcode/support/tests/Makefile
+++ b/chapters/data/memory-security/drills/tasks/exec-shellcode/support/tests/Makefile
@@ -1,6 +1,6 @@
 SRC_PATH ?= ../src
-FULL_SRC_PATH = $(realpath $(SRC_PATH))
-CPPFLAGS = -I. -I$(realpath $(SRC_PATH)) -I../utils
+FULL_SRC_PATH = "$(realpath $(SRC_PATH))"
+CPPFLAGS = -I. -I$(FULL_SRC_PATH) -I../utils
 CFLAGS = -Wall -Wextra
 # Remove the line below to disable debugging support.
 CFLAGS += -g -O0

--- a/chapters/data/process-memory/drills/tasks/page-mapper/support/tests/Makefile
+++ b/chapters/data/process-memory/drills/tasks/page-mapper/support/tests/Makefile
@@ -1,6 +1,6 @@
 SRC_PATH ?= ../src
-FULL_SRC_PATH = $(realpath $(SRC_PATH))
-CPPFLAGS = -I. -I$(realpath $(SRC_PATH)) -I../utils
+FULL_SRC_PATH = "$(realpath $(SRC_PATH))"
+CPPFLAGS = -I. -I$(FULL_SRC_PATH) -I../utils
 CFLAGS = -Wall -Wextra
 # Remove the line below to disable debugging support.
 CFLAGS += -g -O0

--- a/chapters/data/working-with-memory/drills/tasks/access-counter/support/tests/Makefile
+++ b/chapters/data/working-with-memory/drills/tasks/access-counter/support/tests/Makefile
@@ -1,6 +1,6 @@
 SRC_PATH ?= ../src
-FULL_SRC_PATH = $(realpath $(SRC_PATH))
-CPPFLAGS = -I. -I$(realpath $(SRC_PATH)) -I../utils
+FULL_SRC_PATH = "$(realpath $(SRC_PATH))"
+CPPFLAGS = -I. -I$(FULL_SRC_PATH) -I../utils
 CFLAGS = -Wall -Wextra
 # Remove the line below to disable debugging support.
 CFLAGS += -g -O0

--- a/chapters/software-stack/libc/drills/tasks/common-functions/solution/tests/Makefile
+++ b/chapters/software-stack/libc/drills/tasks/common-functions/solution/tests/Makefile
@@ -1,6 +1,6 @@
 SRC_PATH ?= ../src
-FULL_SRC_PATH = $(realpath $(SRC_PATH))
-CPPFLAGS = -I. -I$(realpath $(SRC_PATH)) -I../utils
+FULL_SRC_PATH = "$(realpath $(SRC_PATH))"
+CPPFLAGS = -I. -I$(FULL_SRC_PATH) -I../utils
 CFLAGS = -Wall -Wextra
 # Remove the line below to disable debugging support.
 CFLAGS += -g -O0

--- a/chapters/software-stack/libc/projects/mini-libc/tests/Makefile
+++ b/chapters/software-stack/libc/projects/mini-libc/tests/Makefile
@@ -1,5 +1,5 @@
 SRC_PATH ?= ../src
-FULL_SRC_PATH = $(realpath $(SRC_PATH))
+FULL_SRC_PATH = "$(realpath $(SRC_PATH))"
 CPPFLAGS = -nostdinc -I. -I$(FULL_SRC_PATH)/include
 CFLAGS = -Wall -Wextra -fno-PIC -fno-stack-protector -fno-builtin
 # Remove the line below to disable debugging support.


### PR DESCRIPTION
Fix paths for both `chapters/software-stack` and `chapters/data` so that users with white spaces in directory names can run the Makefile with no error