### PR TITLE
infra/generate_skels: Fix regex warnings

### DIFF
--- a/chapters/data/process-memory/drills/tasks/copy/generate_skels.py
+++ b/chapters/data/process-memory/drills/tasks/copy/generate_skels.py
@@ -93,37 +93,40 @@ def main():
     args = parser.parse_args()
 
     for root, dirs, files in os.walk(args.input):
-        new_root = os.path.join(args.output, root.replace(args.input, "").lstrip("/"))
+        new_root = os.path.join(args.output, os.path.relpath(root, args.input))
         for d in dirs:
             os.makedirs(os.path.join(new_root, d), exist_ok=True)
 
         for src in files:
             if (
                 re.match("Makefile.*$", src)
-                or re.match(".*\.sh$", src)
-                or re.match(".*\.[sS]$", src)
+                or re.match(r".*\.sh$", src)
+                or re.match(r".*\.[sS]$", src)
             ):
-                pattern = "(^\s*#\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*#\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*#\s*REMOVE)( [0-9]*)"
+                pattern = r"(^\s*#\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*#\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*#\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("# ", "")]
                 end_string = None
-            elif re.match(".*\.asm$", src):
-                pattern = "(^\s*;\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*;\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*;\s*REMOVE)( [0-9]*)"
+            elif re.match(r".*\.asm$", src):
+                pattern = r"(^\s*;\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*;\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*;\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("; ", "")]
                 end_string = None
             elif (
-                re.match(".*\.[chd]$", src)
-                or re.match(".*\.cpp$", src)
-                or re.match(".*\.hpp$", src)
+                re.match(r".*\.[ch]$", src)
+                or re.match(r".*\.cpp$", src)
+                or re.match(r".*\.hpp$", src)
             ):
-                pattern = "(.*/\*\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*/\*\s*REPLACE)( [0-9]*)"
-                remove = "(.*/\*\s*REMOVE)( [0-9]*)"
-                replace_pairs = [("/\* ", ""), (" \*/", "")]
+                pattern = r"(.*/\*\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*/\*\s*REPLACE)( [0-9]*)"
+                remove = r"(.*/\*\s*REMOVE)( [0-9]*)"
+                replace_pairs = [(r"/\* ", ""), (r" \*/", "")]
                 end_string = "*/"
+            elif re.match(r".*\.d$", src):
+                pattern = r"(.*//\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*//\s*REPLACE)( [0-9]*)"
             else:
                 continue
 

--- a/chapters/data/working-with-memory/drills/tasks/memory-access/generate_skels.py
+++ b/chapters/data/working-with-memory/drills/tasks/memory-access/generate_skels.py
@@ -93,40 +93,40 @@ def main():
     args = parser.parse_args()
 
     for root, dirs, files in os.walk(args.input):
-        new_root = os.path.join(args.output, root.replace(args.input, ""))
+        new_root = os.path.join(args.output, os.path.relpath(root, args.input))
         for d in dirs:
             os.makedirs(os.path.join(new_root, d), exist_ok=True)
 
         for src in files:
             if (
                 re.match("Makefile.*$", src)
-                or re.match(".*\.sh$", src)
-                or re.match(".*\.[sS]$", src)
+                or re.match(r".*\.sh$", src)
+                or re.match(r".*\.[sS]$", src)
             ):
-                pattern = "(^\s*#\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*#\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*#\s*REMOVE)( [0-9]*)"
+                pattern = r"(^\s*#\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*#\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*#\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("# ", "")]
                 end_string = None
-            elif re.match(".*\.asm$", src):
-                pattern = "(^\s*;\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*;\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*;\s*REMOVE)( [0-9]*)"
+            elif re.match(r".*\.asm$", src):
+                pattern = r"(^\s*;\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*;\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*;\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("; ", "")]
                 end_string = None
             elif (
-                re.match(".*\.[ch]$", src)
-                or re.match(".*\.cpp$", src)
-                or re.match(".*\.hpp$", src)
+                re.match(r".*\.[ch]$", src)
+                or re.match(r".*\.cpp$", src)
+                or re.match(r".*\.hpp$", src)
             ):
-                pattern = "(.*/\*\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*/\*\s*REPLACE)( [0-9]*)"
-                remove = "(.*/\*\s*REMOVE)( [0-9]*)"
-                replace_pairs = [("/\* ", ""), (" \*/", "")]
+                pattern = r"(.*/\*\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*/\*\s*REPLACE)( [0-9]*)"
+                remove = r"(.*/\*\s*REMOVE)( [0-9]*)"
+                replace_pairs = [(r"/\* ", ""), (r" \*/", "")]
                 end_string = "*/"
-            elif re.match(".*\.d$", src):
-                pattern = "(.*//\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*//\s*REPLACE)( [0-9]*)"
+            elif re.match(r".*\.d$", src):
+                pattern = r"(.*//\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*//\s*REPLACE)( [0-9]*)"
             else:
                 continue
 

--- a/chapters/data/working-with-memory/drills/tasks/memory-corruption/generate_skels.py
+++ b/chapters/data/working-with-memory/drills/tasks/memory-corruption/generate_skels.py
@@ -93,37 +93,40 @@ def main():
     args = parser.parse_args()
 
     for root, dirs, files in os.walk(args.input):
-        new_root = os.path.join(args.output, root.replace(args.input, ""))
+        new_root = os.path.join(args.output, os.path.relpath(root, args.input))
         for d in dirs:
             os.makedirs(os.path.join(new_root, d), exist_ok=True)
 
         for src in files:
             if (
                 re.match("Makefile.*$", src)
-                or re.match(".*\.sh$", src)
-                or re.match(".*\.[sS]$", src)
+                or re.match(r".*\.sh$", src)
+                or re.match(r".*\.[sS]$", src)
             ):
-                pattern = "(^\s*#\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*#\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*#\s*REMOVE)( [0-9]*)"
+                pattern = r"(^\s*#\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*#\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*#\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("# ", "")]
                 end_string = None
-            elif re.match(".*\.asm$", src):
-                pattern = "(^\s*;\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*;\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*;\s*REMOVE)( [0-9]*)"
+            elif re.match(r".*\.asm$", src):
+                pattern = r"(^\s*;\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*;\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*;\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("; ", "")]
                 end_string = None
             elif (
-                re.match(".*\.[chd]$", src)
-                or re.match(".*\.cpp$", src)
-                or re.match(".*\.hpp$", src)
+                re.match(r".*\.[ch]$", src)
+                or re.match(r".*\.cpp$", src)
+                or re.match(r".*\.hpp$", src)
             ):
-                pattern = "(.*/\*\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*/\*\s*REPLACE)( [0-9]*)"
-                remove = "(.*/\*\s*REMOVE)( [0-9]*)"
-                replace_pairs = [("/\* ", ""), (" \*/", "")]
+                pattern = r"(.*/\*\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*/\*\s*REPLACE)( [0-9]*)"
+                remove = r"(.*/\*\s*REMOVE)( [0-9]*)"
+                replace_pairs = [(r"/\* ", ""), (r" \*/", "")]
                 end_string = "*/"
+            elif re.match(r".*\.d$", src):
+                pattern = r"(.*//\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*//\s*REPLACE)( [0-9]*)"
             else:
                 continue
 

--- a/chapters/data/working-with-memory/drills/tasks/memory-protection/generate_skels.py
+++ b/chapters/data/working-with-memory/drills/tasks/memory-protection/generate_skels.py
@@ -93,40 +93,40 @@ def main():
     args = parser.parse_args()
 
     for root, dirs, files in os.walk(args.input):
-        new_root = os.path.join(args.output, root.replace(args.input, ""))
+        new_root = os.path.join(args.output, os.path.relpath(root, args.input))
         for d in dirs:
             os.makedirs(os.path.join(new_root, d), exist_ok=True)
 
         for src in files:
             if (
                 re.match("Makefile.*$", src)
-                or re.match(".*\.sh$", src)
-                or re.match(".*\.[sS]$", src)
+                or re.match(r".*\.sh$", src)
+                or re.match(r".*\.[sS]$", src)
             ):
-                pattern = "(^\s*#\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*#\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*#\s*REMOVE)( [0-9]*)"
+                pattern = r"(^\s*#\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*#\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*#\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("# ", "")]
                 end_string = None
-            elif re.match(".*\.asm$", src):
-                pattern = "(^\s*;\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*;\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*;\s*REMOVE)( [0-9]*)"
+            elif re.match(r".*\.asm$", src):
+                pattern = r"(^\s*;\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*;\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*;\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("; ", "")]
                 end_string = None
             elif (
-                re.match(".*\.[ch]$", src)
-                or re.match(".*\.cpp$", src)
-                or re.match(".*\.hpp$", src)
+                re.match(r".*\.[ch]$", src)
+                or re.match(r".*\.cpp$", src)
+                or re.match(r".*\.hpp$", src)
             ):
-                pattern = "(.*/\*\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*/\*\s*REPLACE)( [0-9]*)"
-                remove = "(.*/\*\s*REMOVE)( [0-9]*)"
-                replace_pairs = [("/\* ", ""), (" \*/", "")]
+                pattern = r"(.*/\*\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*/\*\s*REPLACE)( [0-9]*)"
+                remove = r"(.*/\*\s*REMOVE)( [0-9]*)"
+                replace_pairs = [(r"/\* ", ""), (r" \*/", "")]
                 end_string = "*/"
-            elif re.match(".*\.d$", src):
-                pattern = "(.*//\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*//\s*REPLACE)( [0-9]*)"
+            elif re.match(r".*\.d$", src):
+                pattern = r"(.*//\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*//\s*REPLACE)( [0-9]*)"
             else:
                 continue
 

--- a/chapters/software-stack/applications/drills/tasks/app-investigation/generate_skels.py
+++ b/chapters/software-stack/applications/drills/tasks/app-investigation/generate_skels.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3 -u
+# SPDX-License-Identifier: BSD-3-Clause
 
 import sys
 import argparse
@@ -92,40 +93,40 @@ def main():
     args = parser.parse_args()
 
     for root, dirs, files in os.walk(args.input):
-        new_root = os.path.join(args.output, root.replace(args.input, ""))
+        new_root = os.path.join(args.output, os.path.relpath(root, args.input))
         for d in dirs:
             os.makedirs(os.path.join(new_root, d), exist_ok=True)
 
         for src in files:
             if (
                 re.match("Makefile.*$", src)
-                or re.match(".*\.sh$", src)
-                or re.match(".*\.[sS]$", src)
+                or re.match(r".*\.sh$", src)
+                or re.match(r".*\.[sS]$", src)
             ):
-                pattern = "(^\s*#\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*#\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*#\s*REMOVE)( [0-9]*)"
+                pattern = r"(^\s*#\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*#\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*#\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("# ", "")]
                 end_string = None
-            elif re.match(".*\.asm$", src):
-                pattern = "(^\s*;\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*;\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*;\s*REMOVE)( [0-9]*)"
+            elif re.match(r".*\.asm$", src):
+                pattern = r"(^\s*;\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*;\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*;\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("; ", "")]
                 end_string = None
             elif (
-                re.match(".*\.[ch]$", src)
-                or re.match(".*\.cpp$", src)
-                or re.match(".*\.hpp$", src)
+                re.match(r".*\.[ch]$", src)
+                or re.match(r".*\.cpp$", src)
+                or re.match(r".*\.hpp$", src)
             ):
-                pattern = "(.*/\*\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*/\*\s*REPLACE)( [0-9]*)"
-                remove = "(.*/\*\s*REMOVE)( [0-9]*)"
-                replace_pairs = [("/\* ", ""), (" \*/", "")]
+                pattern = r"(.*/\*\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*/\*\s*REPLACE)( [0-9]*)"
+                remove = r"(.*/\*\s*REMOVE)( [0-9]*)"
+                replace_pairs = [(r"/\* ", ""), (r" \*/", "")]
                 end_string = "*/"
-            elif re.match(".*\.d$", src):
-                pattern = "(.*//\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*//\s*REPLACE)( [0-9]*)"
+            elif re.match(r".*\.d$", src):
+                pattern = r"(.*//\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*//\s*REPLACE)( [0-9]*)"
             else:
                 continue
 

--- a/chapters/software-stack/high-level-languages/drills/tasks/high-level-lang/generate_skels.py
+++ b/chapters/software-stack/high-level-languages/drills/tasks/high-level-lang/generate_skels.py
@@ -93,42 +93,40 @@ def main():
     args = parser.parse_args()
 
     for root, dirs, files in os.walk(args.input):
-        new_root = os.path.join(args.output, root.replace(args.input, ""))
+        new_root = os.path.join(args.output, os.path.relpath(root, args.input))
         for d in dirs:
             os.makedirs(os.path.join(new_root, d), exist_ok=True)
 
         for src in files:
             if (
                 re.match("Makefile.*$", src)
-                or re.match(".*\.sh$", src)
-                or re.match(".*\.[sS]$", src)
-                or re.match(".*\.py$", src)
+                or re.match(r".*\.sh$", src)
+                or re.match(r".*\.[sS]$", src)
             ):
-                pattern = "(^\s*#\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*#\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*#\s*REMOVE)( [0-9]*)"
+                pattern = r"(^\s*#\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*#\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*#\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("# ", "")]
                 end_string = None
-            elif re.match(".*\.asm$", src):
-                pattern = "(^\s*;\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*;\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*;\s*REMOVE)( [0-9]*)"
+            elif re.match(r".*\.asm$", src):
+                pattern = r"(^\s*;\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*;\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*;\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("; ", "")]
                 end_string = None
             elif (
-                re.match(".*\.[ch]$", src)
-                or re.match(".*\.cpp$", src)
-                or re.match(".*\.hpp$", src)
-                or re.match(".*\.go$", src)
+                re.match(r".*\.[ch]$", src)
+                or re.match(r".*\.cpp$", src)
+                or re.match(r".*\.hpp$", src)
             ):
-                pattern = "(.*/\*\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*/\*\s*REPLACE)( [0-9]*)"
-                remove = "(.*/\*\s*REMOVE)( [0-9]*)"
-                replace_pairs = [("/\* ", ""), (" \*/", "")]
+                pattern = r"(.*/\*\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*/\*\s*REPLACE)( [0-9]*)"
+                remove = r"(.*/\*\s*REMOVE)( [0-9]*)"
+                replace_pairs = [(r"/\* ", ""), (r" \*/", "")]
                 end_string = "*/"
-            elif re.match(".*\.d$", src):
-                pattern = "(.*//\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*//\s*REPLACE)( [0-9]*)"
+            elif re.match(r".*\.d$", src):
+                pattern = r"(.*//\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*//\s*REPLACE)( [0-9]*)"
             else:
                 continue
 

--- a/chapters/software-stack/libc/drills/tasks/common-functions/generate_skels.py
+++ b/chapters/software-stack/libc/drills/tasks/common-functions/generate_skels.py
@@ -93,40 +93,40 @@ def main():
     args = parser.parse_args()
 
     for root, dirs, files in os.walk(args.input):
-        new_root = os.path.join(args.output, root.replace(args.input, ""))
+        new_root = os.path.join(args.output, os.path.relpath(root, args.input))
         for d in dirs:
             os.makedirs(os.path.join(new_root, d), exist_ok=True)
 
         for src in files:
             if (
                 re.match("Makefile.*$", src)
-                or re.match(".*\.sh$", src)
-                or re.match(".*\.[sS]$", src)
+                or re.match(r".*\.sh$", src)
+                or re.match(r".*\.[sS]$", src)
             ):
-                pattern = "(^\s*#\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*#\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*#\s*REMOVE)( [0-9]*)"
+                pattern = r"(^\s*#\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*#\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*#\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("# ", "")]
                 end_string = None
-            elif re.match(".*\.asm$", src):
-                pattern = "(^\s*;\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*;\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*;\s*REMOVE)( [0-9]*)"
+            elif re.match(r".*\.asm$", src):
+                pattern = r"(^\s*;\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*;\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*;\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("; ", "")]
                 end_string = None
             elif (
-                re.match(".*\.[ch]$", src)
-                or re.match(".*\.cpp$", src)
-                or re.match(".*\.hpp$", src)
+                re.match(r".*\.[ch]$", src)
+                or re.match(r".*\.cpp$", src)
+                or re.match(r".*\.hpp$", src)
             ):
-                pattern = "(.*/\*\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*/\*\s*REPLACE)( [0-9]*)"
-                remove = "(.*/\*\s*REMOVE)( [0-9]*)"
-                replace_pairs = [("/\* ", ""), (" \*/", "")]
+                pattern = r"(.*/\*\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*/\*\s*REPLACE)( [0-9]*)"
+                remove = r"(.*/\*\s*REMOVE)( [0-9]*)"
+                replace_pairs = [(r"/\* ", ""), (r" \*/", "")]
                 end_string = "*/"
-            elif re.match(".*\.d$", src):
-                pattern = "(.*//\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*//\s*REPLACE)( [0-9]*)"
+            elif re.match(r".*\.d$", src):
+                pattern = r"(.*//\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*//\s*REPLACE)( [0-9]*)"
             else:
                 continue
 

--- a/chapters/software-stack/libc/drills/tasks/libc/generate_skels.py
+++ b/chapters/software-stack/libc/drills/tasks/libc/generate_skels.py
@@ -93,40 +93,40 @@ def main():
     args = parser.parse_args()
 
     for root, dirs, files in os.walk(args.input):
-        new_root = os.path.join(args.output, root.replace(args.input, ""))
+        new_root = os.path.join(args.output, os.path.relpath(root, args.input))
         for d in dirs:
             os.makedirs(os.path.join(new_root, d), exist_ok=True)
 
         for src in files:
             if (
                 re.match("Makefile.*$", src)
-                or re.match(".*\.sh$", src)
-                or re.match(".*\.[sS]$", src)
+                or re.match(r".*\.sh$", src)
+                or re.match(r".*\.[sS]$", src)
             ):
-                pattern = "(^\s*#\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*#\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*#\s*REMOVE)( [0-9]*)"
+                pattern = r"(^\s*#\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*#\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*#\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("# ", "")]
                 end_string = None
-            elif re.match(".*\.asm$", src):
-                pattern = "(^\s*;\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*;\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*;\s*REMOVE)( [0-9]*)"
+            elif re.match(r".*\.asm$", src):
+                pattern = r"(^\s*;\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*;\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*;\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("; ", "")]
                 end_string = None
             elif (
-                re.match(".*\.[ch]$", src)
-                or re.match(".*\.cpp$", src)
-                or re.match(".*\.hpp$", src)
+                re.match(r".*\.[ch]$", src)
+                or re.match(r".*\.cpp$", src)
+                or re.match(r".*\.hpp$", src)
             ):
-                pattern = "(.*/\*\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*/\*\s*REPLACE)( [0-9]*)"
-                remove = "(.*/\*\s*REMOVE)( [0-9]*)"
-                replace_pairs = [("/\* ", ""), (" \*/", "")]
+                pattern = r"(.*/\*\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*/\*\s*REPLACE)( [0-9]*)"
+                remove = r"(.*/\*\s*REMOVE)( [0-9]*)"
+                replace_pairs = [(r"/\* ", ""), (r" \*/", "")]
                 end_string = "*/"
-            elif re.match(".*\.d$", src):
-                pattern = "(.*//\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*//\s*REPLACE)( [0-9]*)"
+            elif re.match(r".*\.d$", src):
+                pattern = r"(.*//\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*//\s*REPLACE)( [0-9]*)"
             else:
                 continue
 

--- a/chapters/software-stack/system-calls/drills/tasks/basic-syscall/generate_skels.py
+++ b/chapters/software-stack/system-calls/drills/tasks/basic-syscall/generate_skels.py
@@ -93,40 +93,40 @@ def main():
     args = parser.parse_args()
 
     for root, dirs, files in os.walk(args.input):
-        new_root = os.path.join(args.output, root.replace(args.input, ""))
+        new_root = os.path.join(args.output, os.path.relpath(root, args.input))
         for d in dirs:
             os.makedirs(os.path.join(new_root, d), exist_ok=True)
 
         for src in files:
             if (
                 re.match("Makefile.*$", src)
-                or re.match(".*\.sh$", src)
-                or re.match(".*\.[sS]$", src)
+                or re.match(r".*\.sh$", src)
+                or re.match(r".*\.[sS]$", src)
             ):
-                pattern = "(^\s*#\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*#\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*#\s*REMOVE)( [0-9]*)"
+                pattern = r"(^\s*#\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*#\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*#\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("# ", "")]
                 end_string = None
-            elif re.match(".*\.asm$", src):
-                pattern = "(^\s*;\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*;\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*;\s*REMOVE)( [0-9]*)"
+            elif re.match(r".*\.asm$", src):
+                pattern = r"(^\s*;\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*;\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*;\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("; ", "")]
                 end_string = None
             elif (
-                re.match(".*\.[ch]$", src)
-                or re.match(".*\.cpp$", src)
-                or re.match(".*\.hpp$", src)
+                re.match(r".*\.[ch]$", src)
+                or re.match(r".*\.cpp$", src)
+                or re.match(r".*\.hpp$", src)
             ):
-                pattern = "(.*/\*\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*/\*\s*REPLACE)( [0-9]*)"
-                remove = "(.*/\*\s*REMOVE)( [0-9]*)"
-                replace_pairs = [("/\* ", ""), (" \*/", "")]
+                pattern = r"(.*/\*\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*/\*\s*REPLACE)( [0-9]*)"
+                remove = r"(.*/\*\s*REMOVE)( [0-9]*)"
+                replace_pairs = [(r"/\* ", ""), (r" \*/", "")]
                 end_string = "*/"
-            elif re.match(".*\.d$", src):
-                pattern = "(.*//\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*//\s*REPLACE)( [0-9]*)"
+            elif re.match(r".*\.d$", src):
+                pattern = r"(.*//\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*//\s*REPLACE)( [0-9]*)"
             else:
                 continue
 

--- a/chapters/software-stack/system-calls/drills/tasks/syscall-wrapper/generate_skels.py
+++ b/chapters/software-stack/system-calls/drills/tasks/syscall-wrapper/generate_skels.py
@@ -93,40 +93,40 @@ def main():
     args = parser.parse_args()
 
     for root, dirs, files in os.walk(args.input):
-        new_root = os.path.join(args.output, root.replace(args.input, ""))
+        new_root = os.path.join(args.output, os.path.relpath(root, args.input))
         for d in dirs:
             os.makedirs(os.path.join(new_root, d), exist_ok=True)
 
         for src in files:
             if (
                 re.match("Makefile.*$", src)
-                or re.match(".*\.sh$", src)
-                or re.match(".*\.[sS]$", src)
+                or re.match(r".*\.sh$", src)
+                or re.match(r".*\.[sS]$", src)
             ):
-                pattern = "(^\s*#\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*#\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*#\s*REMOVE)( [0-9]*)"
+                pattern = r"(^\s*#\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*#\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*#\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("# ", "")]
                 end_string = None
-            elif re.match(".*\.asm$", src):
-                pattern = "(^\s*;\s*TODO)( [0-9]*)(:.*)"
-                replace = "(^\s*;\s*REPLACE)( [0-9]*)"
-                remove = "(^\s*;\s*REMOVE)( [0-9]*)"
+            elif re.match(r".*\.asm$", src):
+                pattern = r"(^\s*;\s*TODO)( [0-9]*)(:.*)"
+                replace = r"(^\s*;\s*REPLACE)( [0-9]*)"
+                remove = r"(^\s*;\s*REMOVE)( [0-9]*)"
                 replace_pairs = [("; ", "")]
                 end_string = None
             elif (
-                re.match(".*\.[ch]$", src)
-                or re.match(".*\.cpp$", src)
-                or re.match(".*\.hpp$", src)
+                re.match(r".*\.[ch]$", src)
+                or re.match(r".*\.cpp$", src)
+                or re.match(r".*\.hpp$", src)
             ):
-                pattern = "(.*/\*\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*/\*\s*REPLACE)( [0-9]*)"
-                remove = "(.*/\*\s*REMOVE)( [0-9]*)"
-                replace_pairs = [("/\* ", ""), (" \*/", "")]
+                pattern = r"(.*/\*\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*/\*\s*REPLACE)( [0-9]*)"
+                remove = r"(.*/\*\s*REMOVE)( [0-9]*)"
+                replace_pairs = [(r"/\* ", ""), (r" \*/", "")]
                 end_string = "*/"
-            elif re.match(".*\.d$", src):
-                pattern = "(.*//\s*TODO)([ 0-9]*)(:.*)"
-                replace = "(.*//\s*REPLACE)( [0-9]*)"
+            elif re.match(r".*\.d$", src):
+                pattern = r"(.*//\s*TODO)([ 0-9]*)(:.*)"
+                replace = r"(.*//\s*REPLACE)( [0-9]*)"
             else:
                 continue
 


### PR DESCRIPTION
# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

* Prefix regex strings with 'r' to avoid syntax warnings for unescaped characters.
* Compute the output path using `os.path.relpath()` instead of string replacement.

GitHub-Fixes: #107