### PR TITLE
chapters/data/memory-security: Fix drill path

### DIFF
--- a/chapters/data/memory-security/drills/tasks/pointer-arithmetic-leak/README.md
+++ b/chapters/data/memory-security/drills/tasks/pointer-arithmetic-leak/README.md
@@ -1,6 +1,6 @@
 # Wild Pointer Arithmetic Info Leak
 
-Navigate to the `chapters/data/memory-security/drills/tasks/bypassing-stack-protector/support/` directory.
+Navigate to the `chapters/data/memory-security/drills/tasks/pointer-arithmetic-leak/support/` directory.
 Open and analyze the `buff_leak.c` file.
 
 The pointer `p` points to the stack.


### PR DESCRIPTION
Replaced pointer-arithmetic-leak guide path
from `bypassing-stack-protector`
to `pointer-arithmetic-leak`.

# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
