### PR TITLE
chapters/data/memory-security: Fix "Bypassing the Stack Protector" Task

### DIFF
--- a/chapters/data/memory-security/drills/tasks/bypassing-stack-protector/support/Makefile
+++ b/chapters/data/memory-security/drills/tasks/bypassing-stack-protector/support/Makefile
@@ -1,7 +1,7 @@
 CC = gcc
 SRCS = stack_protector.c
 OBJS = $(SRCS:.c=.o)
-CFLAGS += -fno-stack-protector -fno-PIC
+CFLAGS += -fno-PIC
 LDFLAGS += -no-pie
 TARGET = stack_protector
 


### PR DESCRIPTION
Remove `-fno-stack-protector` option from Makefile in order to include the stack canary to be bypassed.

# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [ ] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
