### PR TITLE
compute/lectures: Fix paths to generated gifs

### DIFF
--- a/chapters/compute/Makefile
+++ b/chapters/compute/Makefile
@@ -6,7 +6,6 @@ FFMPEG = ffmpeg
 
 SLIDES ?= slides.mdpp
 SLIDES_OUT ?= slides.md
-MEDIA_DIR ?= generated-media
 SITE ?= _site
 OPEN ?= xdg-open
 
@@ -21,17 +20,17 @@ $(SITE): $(SLIDES)
 	$(RVMD) $(SLIDES_OUT) --static $@
 
 videos:
-	mkdir -p $(MEDIA_DIR)
 	for TARGET in $(TARGETS); do \
 		TARGET_DIR=$$(find -name $$TARGET -type d | grep media); \
+		MEDIA_DIR=$$(dirname $$TARGET_DIR); \
 		$(FFMPEG) -framerate 0.5 -f image2 -y \
-			-i "$$TARGET_DIR/$$TARGET-%d.svg" -vf format=yuv420p $(MEDIA_DIR)/$$TARGET-generated.gif; \
+			-i "$$TARGET_DIR/$$TARGET-%d.svg" -vf format=yuv420p $$MEDIA_DIR/$$TARGET-generated.gif; \
 	done
 
 open: $(SITE)
 	$(OPEN) $</index.html
 
 clean:
-	-rm -f $(MEDIA_DIR)/*-generated.gif
+	-for i in $$(find -name "*-generated.gif"); do rm -f $$i; done
 	-rm -f *~
 	-rm -fr $(SITE) $(SLIDES_OUT)

--- a/chapters/compute/scheduling/slides/scheduling-algorithms.md
+++ b/chapters/compute/scheduling/slides/scheduling-algorithms.md
@@ -74,7 +74,7 @@
 
 #### Round-Robin - Live Scheduling
 
-![Round-Robin Scheduling](../generated-media/round-robin-generated.gif)
+![Round-Robin Scheduling](synchronization/generated-media/round-robin-generated.gif)
 
 ----
 

--- a/chapters/compute/synchronization/slides/synchronization.md
+++ b/chapters/compute/synchronization/slides/synchronization.md
@@ -28,7 +28,7 @@
 * `demo/race-condition/race_condition.c`
 * `var++` equivalency (**critical section**):
 
-![Race Condition - Instructions](../generated-media/race-condition-generated.gif)
+![Race Condition - Instructions](synchronization/media/race-condition-generated.gif)
 
 * In the end `var = 1` or `var = 2`
 
@@ -44,7 +44,7 @@ if (lock = 0) {
 }
 ```
 
-![Race Condition - TOCTOU](../generated-media/race-condition-toctou-generated.gif)
+![Race Condition - TOCTOU](synchronization/media/race-condition-toctou-generated.gif)
 
 * **Wrong:** threads enter critical section simultaneously
 
@@ -54,7 +54,7 @@ if (lock = 0) {
 
 * Only allow **one thread** to access the critical section at a given time (mutual exclusion)
 
-![Race Condition - Using a lock](../generated-media/race-condition-lock-generated.gif)
+![Race Condition - Using a lock](synchronization/media/race-condition-lock-generated.gif)
 
 * In the end `var` is **always** 2
 * [Quiz](../drills/questions/not-race-condition.md)


### PR DESCRIPTION
# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

Update Makefile to generate all gifs in the media directory. Reference the images using `<section>/media/<file>` to enable rendering on Docusaurus, even though it breaks in-file links.