### PR TITLE
chapters/compute: Fix path for `make skels`

### DIFF
--- a/chapters/io/file-descriptors/drills/tasks/my-cat/Makefile
+++ b/chapters/io/file-descriptors/drills/tasks/my-cat/Makefile
@@ -3,7 +3,7 @@ SCRIPT = generate_skels.py
 
 skels:
 	mkdir -p support/
-	$(PYTHON) $(SCRIPT) --input ./solution/src --output ./support/src
+	$(PYTHON) $(SCRIPT) --input ./solution/ --output ./support/
 
 clean:
 	rm -rf support/


### PR DESCRIPTION
# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

The makefile for the `my-cat` task now uses the correct paths `solution/` and `support/` to generate the support code.