### PR TITLE
chapters/io: Fix wwrite and rread logic from my-cat

### DIFF
--- a/chapters/io/file-descriptors/drills/tasks/mmap_cp/solution/src/mmap_cp.c
+++ b/chapters/io/file-descriptors/drills/tasks/mmap_cp/solution/src/mmap_cp.c
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
 	 * of the output file to the size of the input file.
 	 */
 
-	/* TODO 2: Use ftstat() to get the size of the input file. */
+	/* TODO 2: Use fstat() to get the size of the input file. */
 	rc = fstat(fdin, &statbuf);
 	DIE(rc < 0, "fstat");
 

--- a/chapters/io/file-descriptors/drills/tasks/my-cat/solution/src/my_cat.c
+++ b/chapters/io/file-descriptors/drills/tasks/my-cat/solution/src/my_cat.c
@@ -25,7 +25,7 @@ size_t rread(int fd, void *buf, size_t size)
 	size_t total_bytes_read = 0;
 
 	while (true) {
-		bytes_read = read(fd, buf, size);
+		bytes_read = read(fd, buf + total_bytes_read, size - total_bytes_read);
 		DIE(bytes_read < 0, "read");
 
 		if (bytes_read == 0)
@@ -57,7 +57,7 @@ size_t wwrite(int fd, const void *buf, size_t size)
 	size_t total_bytes_written = 0;
 
 	while (true) {
-		bytes_written = write(fd, buf, size);
+		bytes_written = write(fd, buf + total_bytes_written, size - total_bytes_written);
 		DIE(bytes_written < 0, "write");
 
 		total_bytes_written += bytes_written;


### PR DESCRIPTION
# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

As per the `read` and `write` syscall wrappers, the functions return the number of bytes that have been successfully read or written. The buffer offset should be updated accordingly, as implemented.
