### PR TITLE
Update lab archive generator workflow

### DIFF
--- a/.github/workflows/lab-archive.yml
+++ b/.github/workflows/lab-archive.yml
@@ -37,6 +37,13 @@ jobs:
             exit 0
           fi
 
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          ls -A *.zip > zip-list
+          git add *.zip
+          git stash
+
           # Create or switch to lab-archives branch
           if git ls-remote --exit-code origin lab-archives; then
             git fetch origin lab-archives
@@ -46,15 +53,12 @@ jobs:
             git rm -rf .
           fi
 
-          # Copy new zips into branch root
-          git add *.zip
+          # Remove old archives
+          for f in $(cat zip-list); do rm "$f"; git rm "$f"; done
+          git commit -m "Remove outdated lab archives for commit $GITHUB_SHA"
 
-          # Only commit if there are changes
-          if ! git diff --cached --quiet; then
-            git config user.name "github-actions[bot]"
-            git config user.email "github-actions[bot]@users.noreply.github.com"
-            git commit -m "Update lab archives for commit $GITHUB_SHA"
-            git push origin lab-archives
-          else
-            echo "No changes to commit."
-          fi
+          # Copy new zips into branch root
+          git stash pop
+          git add *.zip
+          git commit -m "Update lab archives for commit $GITHUB_SHA"
+          git push origin lab-archives

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 *.war
 *.nar
 *.ear
-*.zip
 *.tar.gz
 *.rar
 

--- a/gen-zip.py
+++ b/gen-zip.py
@@ -54,7 +54,7 @@ def find_directories_by_name(dirname):
     matches = []
     for root, dirs, _ in os.walk("."):
         for d in dirs:
-            if d == dirname:
+            if d == dirname and "drills" in root:
                 matches.append(os.path.join(root, d))
     return matches
 


### PR DESCRIPTION
Remove `.zip` from gitignore, this is needed because the workflow will overwrite the changes to the archive if the file is ignored by git. Create a commit for removing the outdated archives, since `git stash pop` will generate a merge conflict otherwise. Check if the name of the task contains `drills`. If it does not, do not add it to the archive.

# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [ ] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [ ] Tested your changes against relevant architectures and platforms;
- [ ] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->
