### PR TITLE
data/tasks/copy: Add a rule to generate in.dat

### DIFF
--- a/chapters/data/process-memory/drills/tasks/copy/solution/src/Makefile
+++ b/chapters/data/process-memory/drills/tasks/copy/solution/src/Makefile
@@ -19,7 +19,7 @@ OBJS = $(SRCS:.c=.o)
 BINARIES = mmap_copy read_write_copy
 
 # Default rule: Build everything
-all: $(BINARIES)
+all: $(BINARIES) in.dat
 
 # Rule to compile the logger
 $(LOGGER_OBJ): $(LOGGER_DIR)/log.c
@@ -37,9 +37,13 @@ mmap_copy: mmap_copy.o $(LOGGER)
 read_write_copy: read_write_copy.o $(LOGGER)
 	$(CC) $(CFLAGS) read_write_copy.o $(LOGGER) -o read_write_copy $(LDFLAGS)
 
+# Rule to create the in.dat file with some contents
+in.dat:
+	echo "Hello, world!" > in.dat
+
 # Clean rule: Remove object files and binaries
 clean:
-	-rm -f $(OBJS) $(BINARIES)
+	-rm -f $(OBJS) $(BINARIES) in.dat
 	@make -C $(LOGGER_DIR) clean  # Clean the logger directory as well
 
 .PHONY: all clean


### PR DESCRIPTION
# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

<!--
Please provide a detailed description of the changes made in this new PR.
-->

- Added new `input` rule to create `in.dat` containing "Hello, world!"
- Updated the `all` target to include `input`, ensuring the file is generated automatically during the build

Fixes #203