### PR TITLE
data/bypassing-stack-protector: Fix canary overwrite

### DIFF
--- a/chapters/data/memory-security/drills/tasks/bypassing-stack-protector/solution/src/stack_protector.c
+++ b/chapters/data/memory-security/drills/tasks/bypassing-stack-protector/solution/src/stack_protector.c
@@ -19,12 +19,15 @@ void fun1(char *p)
 	}
 
 	printf("overwrite canary:\n");
-	/* TODO 1: Add code that overwrites the canary. */
-	addr[6] = 0;
+	/* TODO 1: Add code that overwrites the canary.
+	 * Note: You should get a stack smashing detected error.
+	 * Remove the overwrite after getting the error in order to proceed to the next step.
+	 */
+	addr[1] = 0;
 
 	printf("overwrite return address:\n");
 	/* TODO 2: Add code that overwrites the return address with the address of pawned. */
-	addr[7] = &pawned;
+	addr[3] = &pawned;
 
 	(void) p;
 }


### PR DESCRIPTION
# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

The canary and return address overwrites were done two frames higher (instead of only one).

An explicit statement that the canary overwrite should be commented out before proceeding with replacing the return address with `&pawned` has also been added.

##  Explanation

`addr` points to `[RBP-16]`, since at `[RBP-8]` resides the canary, meaning that `addr[1]` will overwrite it. The return address is found two machine words higher than that, at `[RBP+8]`
