### PR TITLE
compute/synchronization: Fix atomic-assembly typo

### DIFF
--- a/chapters/compute/synchronization/drills/tasks/atomic-assembly/README.md
+++ b/chapters/compute/synchronization/drills/tasks/atomic-assembly/README.md
@@ -7,7 +7,7 @@ This mechanism looks very simple.
 It is but **one instruction prefix**: `lock`.
 It is not an instruction with its own separate opcode, but a prefix that slightly modifies the opcode of the following instructions to make the CPU execute it atomically (i.e. with exclusive access to the data bus).
 
-`lock` must only be place before an instruction that executes a _read-modify-write_ action.
+`lock` must only be placed before an instruction that executes a _read-modify-write_ action.
 For example, we cannot place it before a `mov` instruction, as the action of a `mov` is simply `read` or `write`.
 Instead, we can place it in front of an `inc` instruction if its operand is memory.
 


### PR DESCRIPTION
- Fix typo in drills/tasks/atomic-assembly/README.md

# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

Fixed a typo in the `Atomic Assembly` task description
