### PR TITLE
[compute/copy-on-write]: Add a new quiz about Transparent Huge Pages

### DIFF
--- a/chapters/compute/copy-on-write/drills/questions/huge-page-allocation.md
+++ b/chapters/compute/copy-on-write/drills/questions/huge-page-allocation.md
@@ -18,9 +18,8 @@ How many page faults are registered between step 1 and step 2 after changing `NU
 
 ## Feedback
 
-Only **two** page faults have been triggered thanks to an optimization mechanism called **Transparent Huge Pages (THP)**.
-The code maps 1024 pages of 4 kb each in a _contiguous memory region_.
+The code maps 1024 pages of 4 kb each for a total of 4 mb.
 The kernel attempts to merge them into 2 huge pages of 2 mb each.
-This way, we only need 2 TLB entries (instead of 1024) to address our memory, which reduces TLB misses and improves performance.
+This way, we only need 2 TLB entries (instead of 1024) to manage them.
 Those 2 entries are then mapped to physical memory, causing the page faults.
 You may read more about THP in these [docs from RedHat](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/performance_tuning_guide/s-memory-transhuge) or from the [Linux kernel](https://www.kernel.org/doc/Documentation/vm/transhuge.txt)

--- a/chapters/compute/copy-on-write/drills/questions/huge-page-allocation.md
+++ b/chapters/compute/copy-on-write/drills/questions/huge-page-allocation.md
@@ -1,0 +1,26 @@
+# Huge Page Allocation
+
+## Question Text
+
+How many page faults are registered between step 1 and step 2 after changing `NUM_PAGES` to 1024?
+
+## Question Answers
+
+- 1024
+
+- 1023
+
+- 0
+
++ 2
+
+- 512
+
+## Feedback
+
+Only **two** page faults have been triggered thanks to an optimization mechanism called **Transparent Huge Pages (THP)**.
+The code maps 1024 pages of 4 kb each in a _contiguous memory region_.
+The kernel attempts to merge them into 2 huge pages of 2 mb each.
+This way, we only need 2 TLB entries (instead of 1024) to address our memory, which reduces TLB misses and improves performance.
+Those 2 entries are then mapped to physical memory, causing the page faults.
+You may read more about THP in these [docs from RedHat](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/performance_tuning_guide/s-memory-transhuge) or from the [Linux kernel](https://www.kernel.org/doc/Documentation/vm/transhuge.txt)

--- a/chapters/compute/copy-on-write/guides/fork-faults/README.md
+++ b/chapters/compute/copy-on-write/guides/fork-faults/README.md
@@ -21,8 +21,28 @@ The first one still corresponds to the parent.
 
 [Quiz 2](../tasks/questions/child-faults-after-write.md)
 
-As a bonus, try changing `NUM_PAGES` to a bigger number, such as 1024.
-Compile the program, run it again and see the effects.
+As a **bonus**, you are going to learn about a Linux memory optimization mechanism called [Transparent Huge Pages (THP)](https://docs.kernel.org/admin-guide/mm/transhuge.html) and its effects on the TLB.
+If we were to `mmap`, for example, 1024 _contiguous_ pages (of 4 kb each) in memory, they would occupy 1024 entries in the page table and, in turn, in the TLB.
+However, they can be managed much more efficiently using THP.
+It works by taking that memory region and remapping it using **huge pages** of a fixed size each (for example: 2mb).
+This way, we may address the same memory using a lot less TLB entries, boosting performance.
+
+To enable this mechanism on your system, run the following command:
+
+```console
+student@os:~/.../fork-faults/support$ sudo bash -c "echo always > /sys/kernel/mm/transparent_hugepage/enabled"
+```
+
+No need to worry about breaking anything.
+It lasts only for this session (i.e. it resets on reboot).
+
+Now, enable THP for pages of a specific size, such as 2 mb:
+
+```console
+student@os:~/.../fork-faults/support$ sudo bash -c "echo always > /sys/kernel/mm/transparent_hugepage/hugepages-2048kB/enabled"
+```
+
+Set `NUM_PAGES` to 1024 in `fork-faults.c`, recompile the program and see the results.
 
 [Quiz 3](../tasks/questions/huge-page-allocation.md)
 

--- a/chapters/compute/copy-on-write/guides/fork-faults/README.md
+++ b/chapters/compute/copy-on-write/guides/fork-faults/README.md
@@ -21,6 +21,11 @@ The first one still corresponds to the parent.
 
 [Quiz 2](../tasks/questions/child-faults-after-write.md)
 
+As a bonus, try changing `NUM_PAGES` to a bigger number, such as 1024.
+Compile the program, run it again and see the effects.
+
+[Quiz 3](../tasks/questions/huge-page-allocation.md)
+
 Now it should be clear how demand paging differs from copy-on-write.
 Shared memory is a similar concept.
 It's a way of marking certain allocated pages so that copy-on-write is disabled.

--- a/chapters/compute/copy-on-write/guides/fork-faults/support/fork_faults.c
+++ b/chapters/compute/copy-on-write/guides/fork-faults/support/fork_faults.c
@@ -9,7 +9,7 @@
 
 #include "utils/utils.h"
 
-#define NUM_PAGES	1024
+#define NUM_PAGES	256
 
 static void wait_for_input(const char *msg)
 {

--- a/config.yaml
+++ b/config.yaml
@@ -337,6 +337,7 @@ docusaurus:
                   - Semaphore Equivalent: semaphore-equivalent.md
                   - Coarse vs Granular Critical Section: coarse-vs-granular-critical-section.md
                   - Not Race Condition: not-race-condition.md
+                  - Huge Page Allocation: huge-page-allocation.md
             - Lab 6 - Multiprocess and Multithread: lab6.md
             - Lab 7 - Copy-on-Write: lab7.md
             - Lab 8 - Synchronization: lab8.md


### PR DESCRIPTION
# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

- Change `NUM_PAGES` to 256 in the `fork-faults` guide to avoid [Transparent Huge Pages](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/6/html/performance_tuning_guide/s-memory-transhuge) (THP) being triggered
  - Previously, the number was set to 1024, which triggered the THP mechanism
  - The students would have only seen 2 page faults from the parent program instead of the expected 1024 (as per the course material), which was counterintuitive
- Create a new quiz about THP
  - Added explanations about THP
  - Included external resources for further reading
- Add the new quiz in `config.yaml`