### PR TITLE
software-stack/drills: Update task path and instructions in README

### DIFF
--- a/chapters/software-stack/system-calls/drills/tasks/syscall-wrapper/README.md
+++ b/chapters/software-stack/system-calls/drills/tasks/syscall-wrapper/README.md
@@ -1,6 +1,7 @@
 # System Call Wrappers
 
-Enter the `syscall-wrapper/` directory from the extracted archive (or `chapters/software-stack/system-calls/syscall-wrapper/drills/tasks/support/` if you are working directly in the repository) and run `make`, then go through the practice items below.
+Enter the `syscall-wrapper/` directory from the extracted archive (or `chapters/software-stack/system-calls/drills/tasks/syscall-wrapper/` if you are working directly in the repository).
+Run `make` and then enter `support/` folder and go through the practice items below.
 
 1. Update the files in the `support/` folder to make `read` system call available as a wrapper.
    Make a call to the `read` system call to read data from standard input in a buffer.


### PR DESCRIPTION
The path for the System Call Wrappers task was wrong. This commit solves this issue, as well as clarifying we need to run `make` before entering `support/`.

# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

Real path is `chapters/software-stack/system-calls/drills/tasks/syscall-wrapper/`, so the path was wrong from the get-go, aside from the `support/` directory not existing before running `make`. Made sure this is clarified as well in the README.