### PR TITLE
io/ipc/drills: Fix missing closing brace during make process

### DIFF
--- a/chapters/io/ipc/drills/tasks/named-pipes/solution/src/named_pipe.c
+++ b/chapters/io/ipc/drills/tasks/named-pipes/solution/src/named_pipe.c
@@ -14,7 +14,7 @@ static const char fifo_path[] = "my-fifo";
 
 void create_fifo_if_needed(void)
 {
-	/* TODO 9: Use access() to check if the FIFO exists and has the right permissions.
+	/* TODO 8: Use access() to check if the FIFO exists and has the right permissions.
 	 * If it exists but has the wrong permissions, delete it using unlink().
 	 * If it doesn't exist create it using mkfifo().
 	 */


### PR DESCRIPTION
# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

During the build process, an extra line was removed from the source file,
which caused the closing brace of a function to be deleted. This resulted
in a syntax error and prevented the code from compiling correctly.

The issue was caused by an incorrect TODO marker in
chapters/io/ipc/drills/tasks/named-pipes/solution/src/named_pipe.c.
This pull request fixes the problem by changing the comment from TODO 9
to TODO 8, ensuring the make process no longer removes the closing brace.
