### PR TITLE
io/drills: Fix internal and deployment broken references

### DIFF
--- a/chapters/io/ipc/drills/tasks/client-server/README.md
+++ b/chapters/io/ipc/drills/tasks/client-server/README.md
@@ -3,7 +3,7 @@
 Navigate to `client-server` directory of the extracted archive (or `chapters/io/ipc/drills/tasks/client-server/` if you are working directly in the repository) and run `make` to generate the `support` directory.
 This exercise will guide you in creating a basic messaging protocol between a server and a client.
 Although in real-world applications a server typically handles multiple connections at once, here we focus on a single connection.
-Handling multiple connections is further explored in [I/O multiplexing](../../../../io-multiplexing/reading/io-multiplexing.md).
+Handling multiple connections is further explored in [I/O multiplexing](../../../../optimizations/reading/io-multiplexing.md).
 
 Our application protocol is defined as follows:
 
@@ -14,7 +14,7 @@ Our application protocol is defined as follows:
 - The communication ends when either the **client** or the **server** sends the message `exit`.
 
 Since we are blocking on `recv()`, the message order is fixed - the client **must** initiate communication.
-In real-world applications, this constraint can be avoided with [I/O multiplexing](../../../../io-multiplexing/reading/io-multiplexing.md).
+In real-world applications, this constraint can be avoided with [I/O multiplexing](../../../../optimizations/reading/io-multiplexing.md).
 To use the checker, run `make check` from `support`, it will test the client and afterwards the server.
 You **must** implement the client first to later test the server using the checker.
 

--- a/gen-view.py
+++ b/gen-view.py
@@ -163,7 +163,7 @@ def solve_links(filename: str, fileToLab: dict) -> str:
         # Get the first line of the file to extract the chapter in hyphenated format
         try:
             with open(filepath) as f:
-                title = f.readline().strip("#").replace("`", "").replace(":", "")
+                title = f.readline().strip("#").replace("`", "").replace(":", "").replace("/", "")
                 subchapter = prefix + hyphenate(title)
         except:
             print(f"Error: Could not solve link to {filepath} for {filename}")


### PR DESCRIPTION
- Internal reference path for the I/O multiplexing page was wrong, it now links to the correct markdown file
- Deployment reference link to the I/O multiplexing page is now stripped of the `/` in the `title` variable since docusaurus strips punctuation in links by default

# Prerequisite Checklist

<!--
Please mark items appropriately:
-->

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

- Internal reference path for the I/O multiplexing page was wrong, it now links to the correct markdown file
- Deployment reference link to the I/O multiplexing page is now stripped of the `/` in the `title` variable since docusaurus strips punctuation in links by default
