### PR TITLE
software-stack/libc/drills: Fix extra closing brace caused by incorrect TODO marker

### DIFF
--- a/chapters/io/ipc/drills/tasks/named-pipes/solution/src/named_pipe.c
+++ b/chapters/io/ipc/drills/tasks/named-pipes/solution/src/named_pipe.c
@@ -14,7 +14,7 @@ static const char fifo_path[] = "my-fifo";
 
 void create_fifo_if_needed(void)
 {
-	/* TODO 9: Use access() to check if the FIFO exists and has the right permissions.
+	/* TODO 8: Use access() to check if the FIFO exists and has the right permissions.
 	 * If it exists but has the wrong permissions, delete it using unlink().
 	 * If it doesn't exist create it using mkfifo().
 	 */

--- a/chapters/software-stack/libc/drills/tasks/common-functions/solution/src/os_string.c
+++ b/chapters/software-stack/libc/drills/tasks/common-functions/solution/src/os_string.c
@@ -23,7 +23,7 @@ char *os_strcpy(char *dest, const char *src)
 	return dest;
 }
 
-/* TODO 25: Implement os_strcat(). */
+/* TODO 26: Implement os_strcat(). */
 char *os_strcat(char *dest, const char *src)
 {
     char *rdest = dest;


### PR DESCRIPTION
# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes
This pull request fixes a build issue in the common functions task where an
extra closing brace (`}`) remained in the generated source code, causing a
compilation error.

The issue was caused by an incorrect TODO marker in
chapters/software-stack/libc/drills/tasks/common-functions/solution/src/os_string.c.
Changing the comment from TODO 25 to TODO 26 removes the extra closing brace
and restores correct compilation.