### PR TITLE
software-stack/libc/drills: Fix extra closing brace cause by incorrect TODO marker

### DIFF
--- a/chapters/software-stack/libc/drills/tasks/common-functions/solution/src/os_string.c
+++ b/chapters/software-stack/libc/drills/tasks/common-functions/solution/src/os_string.c
@@ -23,7 +23,7 @@ char *os_strcpy(char *dest, const char *src)
 	return dest;
 }
 
-/* TODO 25: Implement os_strcat(). */
+/* TODO 26: Implement os_strcat(). */
 char *os_strcat(char *dest, const char *src)
 {
     char *rdest = dest;


### PR DESCRIPTION
# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/cs-pub-ro/operating-systems/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [x] Updated relevant documentation (if needed).

## Description of changes

This pull request fixes a build issue in the common functions task where an
extra closing brace (`}`) remained in the generated source code, causing a
compilation error.

The issue was caused by an incorrect TODO marker in
chapters/software-stack/libc/drills/tasks/common-functions/solution/src/os_string.c.
Changing the comment from TODO 25 to TODO 26 removes the extra closing brace
and restores correct compilation.
